### PR TITLE
Fix pixel blurring

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,9 @@ fn main() {
                 ..default()
             }),
             ..default()
-        }))
+        }).set(
+            ImagePlugin::default_nearest()
+        ))
         .init_resource::<resources::setting::Setting>()
         .init_resource::<resources::dictionary::Dictionary>()
         .add_state::<scenes::SceneState>()


### PR DESCRIPTION
This is due to the default scaling method, changed to default nearest for pixel perfect scaling.